### PR TITLE
Update eslint-config-prettier to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@typescript-eslint/parser": "^4.6.0",
     "cpx": "^1.5.0",
     "eslint": "^7.12.0",
-    "eslint-config-prettier": "^7.0.0",
+    "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "gas-webpack-plugin": "^1.0.2",
     "jest": "^26.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,10 +1844,10 @@ escodegen@1.14.3, escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.0.0.tgz#c1ae4106f74e6c0357f44adb076771d032ac0e97"
-  integrity sha512-8Y8lGLVPPZdaNA7JXqnvETVC7IiVRgAP6afQu9gOQRn90YY3otMNh+x7Vr2vMePQntF+5erdSUBqSzCmU/AxaQ==
+eslint-config-prettier@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.0.0.tgz#024d661444319686c588c8849c8da33815dbdb1c"
+  integrity sha512-5EaAVPsIHu+grmm5WKjxUia4yHgRrbkd8I0ffqUSwixCPMVBrbS97UnzlEY/Q7OWo584vgixefM0kJnUfo/VjA==
 
 eslint-plugin-prettier@^3.1.2:
   version "3.1.4"


### PR DESCRIPTION
## Version **8.0.0** of **eslint-config-prettier** was just published.

* Package: [repository](https://github.com/prettier/eslint-config-prettier.git), [npm](https://www.npmjs.com/package/eslint-config-prettier)
* Current Version: 7.0.0
* Dev: true
* [compare 7.0.0 to 8.0.0 diffs](https://github.com/prettier/eslint-config-prettier/compare/v7.0.0...v8.0.0)

The version(`8.0.0`) is **not covered** by your current version range(`^7.0.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: