### PR TITLE
Update gas-webpack-plugin to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "eslint": "^7.12.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "gas-webpack-plugin": "^1.0.2",
+    "gas-webpack-plugin": "^2.0.0",
     "jest": "^26.6.1",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,7 +1832,19 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escodegen@1.14.3, escodegen@^1.14.1:
+escodegen@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
+  integrity sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
+escodegen@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
@@ -1967,20 +1979,20 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@5.1.0, estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+estraverse@5.2.0, estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+estraverse@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
+  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -2299,21 +2311,23 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gas-entry-generator@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/gas-entry-generator/-/gas-entry-generator-1.1.2.tgz#52fd86660f9d12263e64da7a26bb9e6df1bc52a4"
-  integrity sha512-OH5HTs9AfwA59hkZVniqzrYypm5fmtUT9JoHXBoH/qBKBrwhofnbcSjBIlhHgociDePEHC7q6HGC0i/QgGqYpw==
+gas-entry-generator@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gas-entry-generator/-/gas-entry-generator-2.1.0.tgz#f35557de34fcab15ca0201d639b2246e1cf4e9b7"
+  integrity sha512-IjbVuMjXlRP1zIJJGgSyOb5SjlVxnAdtLDp+aCdXNuZBg7OuD10WVtkJSCcf33VXcPe4AqWb8z+ucsXZMClsAA==
   dependencies:
-    escodegen "1.14.3"
+    escodegen "2.0.0"
     esprima "4.0.1"
-    estraverse "5.1.0"
+    estraverse "5.2.0"
 
-gas-webpack-plugin@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/gas-webpack-plugin/-/gas-webpack-plugin-1.0.3.tgz#9c5af2e4456228451607bd48674e33f53e228dcd"
-  integrity sha512-JVGdkBeVNYakMc63bSWic+fCHBng2E8+yRGhM0RxOF3PKQNqHmtLD83Ggr+vdxyQ+SPK6KAB2xTvBHcckEIK/g==
+gas-webpack-plugin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gas-webpack-plugin/-/gas-webpack-plugin-2.0.0.tgz#a6f066870ba90bad52c7441640e3fcc6682d8cba"
+  integrity sha512-Sto7WWbAUhka4VtFQ20/dczQgalRFnrGTp9D29QRwbj+wfevoZETSk7UBgsWe6OXrCn94nn8ORJ6D7ZBfo/Pqg==
   dependencies:
-    gas-entry-generator "1.1.2"
+    gas-entry-generator "2.1.0"
+    minimatch "^3.0.4"
+    webpack-sources "^1.4.3"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -4461,7 +4475,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-source-list-map@^2.0.1:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -5082,6 +5096,14 @@ webpack-merge@^4.2.2:
   integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
   dependencies:
     lodash "^4.17.15"
+
+webpack-sources@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
+  integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
 
 webpack-sources@^2.0.1:
   version "2.1.0"


### PR DESCRIPTION
## Version **2.0.0** of **gas-webpack-plugin** was just published.

* Package: [repository](https://github.com/fossamagna/gas-webpack-plugin.git), [npm](https://www.npmjs.com/package/gas-webpack-plugin)
* Current Version: 1.0.3
* Dev: true
* [compare 1.0.3 to 2.0.0 diffs](https://github.com/fossamagna/gas-webpack-plugin/compare/v1.0.3...v2.0.0)

The version(`2.0.0`) is **not covered** by your current version range(`^1.0.2`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: