### PR TITLE
Update eslint-plugin-prettier to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cpx": "^1.5.0",
     "eslint": "^7.12.0",
     "eslint-config-prettier": "^8.0.0",
-    "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-prettier": "^4.0.0",
     "gas-webpack-plugin": "^2.0.0",
     "jest": "^27.0.1",
     "prettier": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2003,10 +2003,10 @@ eslint-config-prettier@^8.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.0.0.tgz#024d661444319686c588c8849c8da33815dbdb1c"
   integrity sha512-5EaAVPsIHu+grmm5WKjxUia4yHgRrbkd8I0ffqUSwixCPMVBrbS97UnzlEY/Q7OWo584vgixefM0kJnUfo/VjA==
 
-eslint-plugin-prettier@^3.1.2:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
-  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION
## Version **4.0.0** of **eslint-plugin-prettier** was just published.

* Package: [repository](https://github.com/prettier/eslint-plugin-prettier.git), [npm](https://www.npmjs.com/package/eslint-plugin-prettier)
* Current Version: 3.1.4
* Dev: true
* [compare 3.1.4 to 4.0.0 diffs](https://github.com/prettier/eslint-plugin-prettier/compare/v3.1.4...v4.0.0)

The version(`4.0.0`) is **not covered** by your current version range(`^3.1.2`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: