### PR TITLE
Update eslint to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "cpx": "^1.5.0",
-    "eslint": "^7.12.0",
+    "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "gas-webpack-plugin": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
+"@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
   integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
@@ -473,21 +473,34 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eslint/eslintrc@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.0.tgz#bc7e3c4304d4c8720968ccaee793087dfb5fe6b4"
-  integrity sha512-+cIGPCBdLCzqxdtwppswP+zTsH9BOIGzAeKfBIbtb4gW/giMlfMwP0HUSFfhzh20f9u8uZ8hOp62+4GPquTbwQ==
+"@eslint/eslintrc@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.2.tgz#6044884f7f93c4ecc2d1694c7486cce91ef8f746"
+  integrity sha512-x1ZXdEFsvTcnbTZgqcWUL9w2ybgZCw/qbKTPQnab+XnYA2bMQpJCh+/bBzCRfDJaJdlrrQlOk49jNtru9gL/6Q==
   dependencies:
     ajv "^6.12.4"
-    debug "^4.1.1"
-    espree "^7.3.0"
-    globals "^12.1.0"
+    debug "^4.3.2"
+    espree "^9.0.0"
+    globals "^13.9.0"
     ignore "^4.0.6"
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
-    lodash "^4.17.19"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
+
+"@humanwhocodes/config-array@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.6.0.tgz#b5621fdb3b32309d2d16575456cbc277fa8f021a"
+  integrity sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.0"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/object-schema@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
+  integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1141,10 +1154,10 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
-  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
+acorn-jsx@^5.3.1:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn-walk@^7.1.1:
   version "7.2.0"
@@ -1156,11 +1169,6 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
-acorn@^7.4.0:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
 acorn@^8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.4.tgz#7a3ae4191466a6984eee0fe3407a4f3aa9db8354"
@@ -1170,6 +1178,11 @@ acorn@^8.2.4:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
   integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
+
+acorn@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
+  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
 
 agent-base@6:
   version "6.0.2"
@@ -1183,7 +1196,7 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.10.0, ajv@^6.10.2:
+ajv@^6.10.0:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
@@ -1215,17 +1228,12 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
 ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -1267,6 +1275,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -1314,11 +1327,6 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
-
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-each@^1.0.0:
   version "1.0.3"
@@ -1801,12 +1809,19 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 decimal.js@^10.2.1:
   version "10.2.1"
@@ -1921,11 +1936,6 @@ emittery@^0.8.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
   integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
 
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1986,6 +1996,11 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@2.0.0, escodegen@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
@@ -2026,14 +2041,29 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.0.0, eslint-utils@^2.1.0:
+eslint-scope@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-6.0.0.tgz#9cf45b13c5ac8f3d4c50f46a5121f61b3e318978"
+  integrity sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-utils@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -2043,67 +2073,73 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.12.0:
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.12.0.tgz#7b6a85f87a9adc239e979bb721cde5ce0dc27da6"
-  integrity sha512-n5pEU27DRxCSlOhJ2rO57GDLcNsxO0LPpAbpFdh7xmcDmjmlGUfoyrsB3I7yYdQXO5N3gkSTiDrPSPNFiiirXA==
+eslint-visitor-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz#e32e99c6cdc2eb063f204eda5db67bfe58bb4186"
+  integrity sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==
+
+eslint@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.0.0.tgz#2c2d0ac6353755667ac90c9ff4a9c1315e43fcff"
+  integrity sha512-03spzPzMAO4pElm44m60Nj08nYonPGQXmw6Ceai/S4QK82IgwWO1EXx1s9namKzVlbVu3Jf81hb+N+8+v21/HQ==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.2.0"
+    "@eslint/eslintrc" "^1.0.2"
+    "@humanwhocodes/config-array" "^0.6.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
-    debug "^4.0.1"
+    debug "^4.3.2"
     doctrine "^3.0.0"
     enquirer "^2.3.5"
-    eslint-scope "^5.1.1"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^2.0.0"
-    espree "^7.3.0"
-    esquery "^1.2.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^6.0.0"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.0.0"
+    espree "^9.0.0"
+    esquery "^1.4.0"
     esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
-    glob-parent "^5.0.0"
-    globals "^12.1.0"
+    glob-parent "^6.0.1"
+    globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
-    js-yaml "^3.13.1"
+    js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.19"
+    lodash.merge "^4.6.2"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
     progress "^2.0.0"
-    regexpp "^3.1.0"
+    regexpp "^3.2.0"
     semver "^7.2.1"
     strip-ansi "^6.0.0"
     strip-json-comments "^3.1.0"
-    table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
-  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
+espree@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.0.0.tgz#e90a2965698228502e771c7a58489b1a9d107090"
+  integrity sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==
   dependencies:
-    acorn "^7.4.0"
-    acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.3.0"
+    acorn "^8.5.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^3.0.0"
 
 esprima@4.0.1, esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
-  integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
@@ -2256,7 +2292,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -2302,12 +2338,12 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-file-entry-cache@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
-  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
-    flat-cache "^2.0.1"
+    flat-cache "^3.0.4"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -2360,19 +2396,18 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
 
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+flatted@^3.1.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
+  integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -2500,12 +2535,19 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0:
+glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
+
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -2544,12 +2586,12 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^12.1.0:
-  version "12.4.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
-  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+globals@^13.6.0, globals@^13.9.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.11.0.tgz#40ef678da117fe7bd2e28f1fab24951bd0255be7"
+  integrity sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==
   dependencies:
-    type-fest "^0.8.1"
+    type-fest "^0.20.2"
 
 globby@^11.0.1:
   version "11.0.1"
@@ -2831,11 +2873,6 @@ is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -2857,6 +2894,13 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -3427,6 +3471,13 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsdom@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.6.0.tgz#f79b3786682065492a3da6a60a4695da983805ac"
@@ -3558,6 +3609,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3568,7 +3624,7 @@ lodash@4.x, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -4168,10 +4224,15 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.0.0, regexpp@^3.1.0:
+regexpp@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -4255,14 +4316,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.1:
+rimraf@^3.0.0, rimraf@^3.0.1, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -4393,15 +4447,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
-
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -4511,15 +4556,6 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-string-width@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
@@ -4535,13 +4571,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"
@@ -4615,16 +4644,6 @@ table-layout@^1.0.0:
     deep-extend "~0.6.0"
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
-
-table@^5.2.3:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
-  dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
 
 tapable@^2.0.0:
   version "2.0.0"
@@ -4815,10 +4834,10 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -5080,13 +5099,6 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
 
 ws@^7.4.5:
   version "7.4.6"


### PR DESCRIPTION
## Version **8.0.0** of **eslint** was just published.

* Package: [repository](https://github.com/eslint/eslint.git), [npm](https://www.npmjs.com/package/eslint)
* Current Version: 7.12.0
* Dev: true
* [compare 7.12.0 to 8.0.0 diffs](https://github.com/eslint/eslint/compare/v7.12.0...v8.0.0)

The version(`8.0.0`) is **not covered** by your current version range(`^7.12.0`).

<details>
<summary>Release Notes</summary>
<h1>null</h1>
<ul>
<li><a href="https://github.com/eslint/eslint/commit/7d3f7f01281671c4761f8da0d3ae9882a38eca8a"><code>7d3f7f0</code></a> Upgrade: unfrozen <a href="https://github.com/eslint/eslintrc"><strong>@eslint/eslintrc</strong></a> (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/15036">#15036</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15146">#15146</a>) (Brandon Mills)</li>
<li><a href="https://github.com/eslint/eslint/commit/2174a6f0e5d18b673604d31e3ca7b790cdc9429b"><code>2174a6f</code></a> Fix: require-atomic-updates property assignment message (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/15076">#15076</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15109">#15109</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/f885fe06a0a79d91fc72a132fd31edf9ef0502cd"><code>f885fe0</code></a> Docs: add note and example for extending the range of fix (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/13706">#13706</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/13748">#13748</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/3da1509106f508f0eb8ba48cdfc666225fda7edc"><code>3da1509</code></a> Docs: Add jsdoc <code>type</code> annotation to sample rule (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15085">#15085</a>) (Bryan Mishkin)</li>
<li><a href="https://github.com/eslint/eslint/commit/68a49a9446c3286bb9ff24b90713c794b7e1f6f5"><code>68a49a9</code></a> Docs: Update Rollup Integrations (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15142">#15142</a>) (xiaohai)</li>
<li><a href="https://github.com/eslint/eslint/commit/d867f8100737bb82742debee2b5dc853c5f07c91"><code>d867f81</code></a> Docs: Remove a dot from curly link (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15128">#15128</a>) (Mauro Murru)</li>
<li><a href="https://github.com/eslint/eslint/commit/9f8b91922839b9d438df6cc1d542eea0509ef122"><code>9f8b919</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/4b08f299a172d3eef09e97e85d19a1612e83ac45"><code>4b08f29</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/ebc1ba1416834b7a52d1e16909ba05c731e97ed4"><code>ebc1ba1</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/2d654f115f6e05b59c85434e75cf68204b976f22"><code>2d654f1</code></a> Docs: add example .eslintrc.json (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15087">#15087</a>) (Nicolas Mattia)</li>
<li><a href="https://github.com/eslint/eslint/commit/16034f09ae6c7a78b8268b4c859928f18de7b9d6"><code>16034f0</code></a> Docs: fix fixable example (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15107">#15107</a>) (QiChang Li)</li>
<li><a href="https://github.com/eslint/eslint/commit/07175b8e9532d79e55c499aa27f79f023abda3c3"><code>07175b8</code></a> 8.0.0-rc.0 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/71faa38adada4bd2f1ec0da7e45e6c7c84d1671d"><code>71faa38</code></a> Build: changelog update for 8.0.0-rc.0 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/67c0074fa843fab629f464ff875007a8ee33cc7f"><code>67c0074</code></a> Update: Suggest missing rule in flat config (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14027">#14027</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15074">#15074</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/cf34e5cf5ed5d09eb53c16cca06821c4e34b7b70"><code>cf34e5c</code></a> Update: space-before-blocks ignore after switch colons (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/15082">#15082</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15093">#15093</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/c9efb5f91937dcb6c8f3d7cb2f59940046d77901"><code>c9efb5f</code></a> Fix: preserve formatting when rules are removed from disable directives (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15081">#15081</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/14a4739ab2233acef995a6dde233de05d067a0f3"><code>14a4739</code></a> Update: <code>no-new-func</code> rule catching eval case of <code>MemberExpression</code> (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14860">#14860</a>) (Mojtaba Samimi)</li>
<li><a href="https://github.com/eslint/eslint/commit/7f2346b40ffd0d470092e52b995d7ab2648089db"><code>7f2346b</code></a> Docs: Update release blog post template (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15094">#15094</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/fabdf8a4e2f82b5fe2f903f015c3e60747a0b143"><code>fabdf8a</code></a> Chore: Remove <code>target.all</code> from <code>Makefile.js</code> (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15088">#15088</a>) (Hirotaka Tagawa / wafuwafu13)</li>
<li><a href="https://github.com/eslint/eslint/commit/e3cd1414489ceda460d593ac7e7b14f8ad45d4fc"><code>e3cd141</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/05d7140d46e2b5300d4dc9a60450eed956c95420"><code>05d7140</code></a> Chore: document target global in Makefile.js (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15084">#15084</a>) (Hirotaka Tagawa / wafuwafu13)</li>
<li><a href="https://github.com/eslint/eslint/commit/0a1a850575ca75db017051abe5e931f0f9c8012b"><code>0a1a850</code></a> Update: include <code>ruleId</code> in error logs (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/15037">#15037</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15053">#15053</a>) (Ari Perkkiö)</li>
<li><a href="https://github.com/eslint/eslint/commit/47be8003d700bc0606495ae42610eaba94e639c5"><code>47be800</code></a> Chore: test Property > .key with { a = 1 } pattern (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14799">#14799</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15072">#15072</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/a744dfa1f077afe406014f84135f8d26e9a12a94"><code>a744dfa</code></a> Docs: Update CLA info (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15058">#15058</a>) (Brian Warner)</li>
<li><a href="https://github.com/eslint/eslint/commit/9fb0f7040759ea23538997648f2d2d53e7c9db8a"><code>9fb0f70</code></a> Chore: fix bug report template (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15061">#15061</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/f87e199e988f42fc490890eee0642d86c48c85ff"><code>f87e199</code></a> Chore: Cleanup issue templates (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15039">#15039</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/660f075386d0b700faf1a1a94cde9d51899738a3"><code>660f075</code></a> 8.0.0-beta.2 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/d148ffdec385e832956c748e36941e598b57b031"><code>d148ffd</code></a> Build: changelog update for 8.0.0-beta.2 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/9e5c2e853ace560876c2f2119e134639be8659d0"><code>9e5c2e8</code></a> Upgrade: <a href="https://github.com/eslint/eslintrc"><strong>@eslint/eslintrc</strong></a><a href="https://github.com/1"><strong>@1</strong></a>.0.1 (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15047">#15047</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/7cf96cf185f849d379b660072d660ec35ac5b46d"><code>7cf96cf</code></a> Breaking: Disallow reserved words in ES3 (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/15017">#15017</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15046">#15046</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/88a39520716bdd11f8647e47c57bd8bf91bc7148"><code>88a3952</code></a> Update: support class fields in the <code>complexity</code> rule (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14957">#14957</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/9bd3d87c8d7369e85f2b7d9b784fed8143191d30"><code>9bd3d87</code></a> Fix: semicolon-less style in lines-between-class-members (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15045">#15045</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/6d1ccb676fedd1ceb4b1e44abf8133f116a5aecb"><code>6d1ccb6</code></a> Update: enforceForClassFields in class-methods-use-this (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15018">#15018</a>) (YeonJuan)</li>
<li><a href="https://github.com/eslint/eslint/commit/91e82f5c4cfeab5ac6d01865ce0eb9ea0649df39"><code>91e82f5</code></a> Docs: LintMessage.line and column are possibly undefined (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15032">#15032</a>) (Brandon Mills)</li>
<li><a href="https://github.com/eslint/eslint/commit/921ba1ee53e5f2219f09050565b8d69fab517d72"><code>921ba1e</code></a> Chore: fix failing cli test (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15041">#15041</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/dd5663166a8235512e797522731af1e9651f9392"><code>dd56631</code></a> Docs: remove duplicate code path analysis document (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15033">#15033</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/143a5987f18f063a47a0646fa1e10e0f88602f6f"><code>143a598</code></a> Chore: Switch issues to use forms (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15024">#15024</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/f966fe6286b6f668812f5155b79d4ee2a8b584b3"><code>f966fe6</code></a> Fix: Update semi for class-fields (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14945">#14945</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/8c61f5ac67682fcfec7fc6faafcf72e4b1a339ff"><code>8c61f5a</code></a> Docs: add info about non-capturing groups to prefer-named-capture-group (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15009">#15009</a>) (Andrzej Wódkiewicz)</li>
<li><a href="https://github.com/eslint/eslint/commit/dd109379f730a988a9e6c0102bcfe443ad0b4b94"><code>dd10937</code></a> Update: added ignoreExpressions option to max-classes-per-file (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15000">#15000</a>) (Josh Goldberg)</li>
<li><a href="https://github.com/eslint/eslint/commit/e9764f3e2fe3f7b6341c9a4381f0dcd23548338e"><code>e9764f3</code></a> Fix: no-undef-init should not apply to class fields (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14994">#14994</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/4338b74767fa71e4e8d171f8503aa33d970e509f"><code>4338b74</code></a> Docs: add no-dupe-class-members examples with class fields (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/15005">#15005</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/b4232d47f88611c68a6c0f915b092b68845ecbaf"><code>b4232d4</code></a> Chore: Add test that deprecated rules display a deprecated notice (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14989">#14989</a>) (TagawaHirotaka)</li>
<li><a href="https://github.com/eslint/eslint/commit/88b4e3d191c2577e2e1a283cc5f825feea6271cc"><code>88b4e3d</code></a> Docs: Make clear how rule options are overridden (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14962">#14962</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14976">#14976</a>) (Jake Ob)</li>
<li><a href="https://github.com/eslint/eslint/commit/4165c7f937f5fc46d4209ae8f763238d73f37238"><code>4165c7f</code></a> Docs: Clarify Linter vs ESLint in node.js api docs (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14953">#14953</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14995">#14995</a>) (Brian Bartels)</li>
<li><a href="https://github.com/eslint/eslint/commit/80cfb8f858888bddfefd7de6b4ecbf5aabe267bc"><code>80cfb8f</code></a> Docs: fix typo in migration guide (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14985">#14985</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/1ddc9559dff437c605e33c156b4380246a231a6e"><code>1ddc955</code></a> 8.0.0-beta.1 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/95cc61e40a89aa2278ae93ae2f35c38737280abb"><code>95cc61e</code></a> Build: changelog update for 8.0.0-beta.1 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/05ca24c57f90f91421b682dca3d7a45b7957fb77"><code>05ca24c</code></a> Update: Code path analysis for class fields (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14343">#14343</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14886">#14886</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/db1518374a5e88efedf1ed4609d879f3091af74f"><code>db15183</code></a> Chore: Refactor comments of tests (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14956">#14956</a>) (TagawaHirotaka)</li>
<li><a href="https://github.com/eslint/eslint/commit/396a0e3c7c82e5d2680d07250008094f336856db"><code>396a0e3</code></a> Docs: update ScopeManager with class fields (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14974">#14974</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/6663e7aed498a73108b5e6371f218d9411b87796"><code>6663e7a</code></a> Docs: remove <code>docs</code> script (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14288">#14288</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14971">#14971</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/44c6fc879de61e9513835d1d4d6ae978d9a43c51"><code>44c6fc8</code></a> Update: support class fields in func-name-matching (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14964">#14964</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/44f7de5ee4d934dee540d3d55305126c670f6bfc"><code>44f7de5</code></a> Docs: Update deprecated information (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14961">#14961</a>) (TagawaHirotaka)</li>
<li><a href="https://github.com/eslint/eslint/commit/305e14af8bd12afc01487abee5c9b0f3eaca989e"><code>305e14a</code></a> Breaking: remove meta.docs.category in core rules (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/13398">#13398</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14594">#14594</a>) (薛定谔的猫)</li>
<li><a href="https://github.com/eslint/eslint/commit/a79c9f35d665c2bcc63267bdf359a8176e0a84ce"><code>a79c9f3</code></a> Chore: Enforce jsdoc check-line-alignment never (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14955">#14955</a>) (Brett Zamir)</li>
<li><a href="https://github.com/eslint/eslint/commit/a8bcef70a4a6b1fbb2007075bed754635f27ff01"><code>a8bcef7</code></a> Docs: Add 2021 and 2022 to supported ECMAScript versions (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14952">#14952</a>) (coderaiser)</li>
<li><a href="https://github.com/eslint/eslint/commit/3409785a41a5bd2b128ed11b8baf7a59f9e412ee"><code>3409785</code></a> Fix: camelcase ignoreGlobals shouldn't apply to undef vars (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14966">#14966</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/b301069981dc1dcca51df2813dcebdca8c150502"><code>b301069</code></a> Docs: fix 'When Not To Use' in prefer-named-capture-group (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14959">#14959</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14969">#14969</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/2d18db6278320fb97bc8e0bff3518c790566a6a6"><code>2d18db6</code></a> Chore: add test for merging <code>parserOptions</code> in Linter (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14948">#14948</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/3d7d5fb32425e8c04d3eaa0107a2ab03a2e285df"><code>3d7d5fb</code></a> Update: reporting loc for <code>never</code> option in <code>eol-last</code> (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/12334">#12334</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14840">#14840</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/f110926a7abcc875a86dd13116f794e4f950e2ba"><code>f110926</code></a> Update: fix no-unused-vars false negative with comma operator (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14928">#14928</a>) (Sachin)</li>
<li><a href="https://github.com/eslint/eslint/commit/e98f14d356b5ff934dd2a0a1fb226f1b15317ab3"><code>e98f14d</code></a> Docs: Fix typo in no-implicit-globals.md (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14954">#14954</a>) (jwbth)</li>
<li><a href="https://github.com/eslint/eslint/commit/9a4ae3b68a1afd9483d331997635727fb19a1a99"><code>9a4ae3b</code></a> Chore: Apply comment require-description and check ClassDeclaration (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14949">#14949</a>) (Brett Zamir)</li>
<li><a href="https://github.com/eslint/eslint/commit/8344675c309a359dd2af5afddba6122f5dc803d0"><code>8344675</code></a> Chore: fix small typo (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14951">#14951</a>) (Sosuke Suzuki)</li>
<li><a href="https://github.com/eslint/eslint/commit/26b0cd924e79a0ab2374c0cd813e92055f9fff7b"><code>26b0cd9</code></a> Update: fix no-unreachable logic for class fields (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14920">#14920</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/ee1b54f31fa840e6ec72a313aa4090fdd3e985cd"><code>ee1b54f</code></a> Fix: keyword-spacing private name compat (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14946">#14946</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/58840ac844a61c72eabb603ecfb761812b82a7ed"><code>58840ac</code></a> Chore: Update jsdoc plugin and tweak rules in effect (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14814">#14814</a>) (Brett Zamir)</li>
<li><a href="https://github.com/eslint/eslint/commit/81c60f4a8725738f191580646562d1dca7eee933"><code>81c60f4</code></a> Docs: document ESLint api (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14934">#14934</a>) (Sam Chen)</li>
<li><a href="https://github.com/eslint/eslint/commit/c74fe08642c30e1a4cd4e0866251a2d29466add8"><code>c74fe08</code></a> Build: Force prerelease peer dep for Node 16 in CI (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14933">#14933</a>) (Brandon Mills)</li>
<li><a href="https://github.com/eslint/eslint/commit/c9947d2a3e0250928d4d80f3b287f10e68fc8db2"><code>c9947d2</code></a> 8.0.0-beta.0 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/027165cacf62ab1662f4c343ff30b235fd9d46b8"><code>027165c</code></a> Build: changelog update for 8.0.0-beta.0 (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/be334f9d8633e9d193dcb8b36f484547e9d3ab97"><code>be334f9</code></a> Chore: Fix Makefile call to linter.getRules() (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14932">#14932</a>) (Brandon Mills)</li>
<li><a href="https://github.com/eslint/eslint/commit/0c86b68a6e2435eb03b681b51b099b552b521adc"><code>0c86b68</code></a> Chore: Replace old syntax for Array flat/flatMap (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14614">#14614</a>) (Stephen Wade)</li>
<li><a href="https://github.com/eslint/eslint/commit/6a89f3f7b6a3edb3465952521bdf06a220515b95"><code>6a89f3f</code></a> Chore: ignore <code>yarn-error.log</code> and <code>.pnpm-debug.log</code> (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14925">#14925</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/28fe19c4a9108111932966aa7c9f361c26601d70"><code>28fe19c</code></a> Docs: Add v8.0.0 migration guide (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14856">#14856</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14884">#14884</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/ec9db63e53a6605a558dcd82947d2425f89887c3"><code>ec9db63</code></a> Upgrade: <a href="https://github.com/eslint/eslintrc"><strong>@eslint/eslintrc</strong></a><a href="https://github.com/1"><strong>@1</strong></a>.0.0 (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14865">#14865</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/1f5d0889264c60dddb6fb07a3b1e43f840e84d57"><code>1f5d088</code></a> Docs: add an example <code>Object.assign()</code> for rule no-import-assign (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14916">#14916</a>) (薛定谔的猫)</li>
<li><a href="https://github.com/eslint/eslint/commit/af965848c010612c3e136c367cc9b9e2e822f580"><code>af96584</code></a> Fix: handle computed class fields in operator-linebreak (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14915">#14915</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/3b6cd8934b3640ffb6fa49b471babf07f0ad769a"><code>3b6cd89</code></a> Chore: Add rel/abs path tests in <code>no-restricted-{imports/modules}</code> rules (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14910">#14910</a>) (Bryan Mishkin)</li>
<li><a href="https://github.com/eslint/eslint/commit/62c6fe7d10ff4eeebd196e143f96cfd88818393d"><code>62c6fe7</code></a> Upgrade: Debug 4.0.1 > 4.3.2 (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14892">#14892</a>) (sandesh bafna)</li>
<li><a href="https://github.com/eslint/eslint/commit/f98451584a82e41f82ceacd484ea0fe90aa9ce63"><code>f984515</code></a> Chore: add assertions on reporting location in <code>semi</code> (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14899">#14899</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/a773b99873965652a86bec489193dc42a8923f5f"><code>a773b99</code></a> Fix: no-useless-computed-key edge cases with class fields (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14903">#14903</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/88db3f54988dddfbda35764ecf1ea16354c4213a"><code>88db3f5</code></a> Upgrade: <code>js-yaml</code> to v4 (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14890">#14890</a>) (Bryan Mishkin)</li>
<li><a href="https://github.com/eslint/eslint/commit/cbc43daad2ea229fb15a9198efd2bc2721dfb75f"><code>cbc43da</code></a> Fix: prefer-destructuring PrivateIdentifier false positive (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14897">#14897</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/ccb9a9138acd63457e004630475495954c1be6f4"><code>ccb9a91</code></a> Fix: dot-notation false positive with private identifier (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14898">#14898</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/8c350660e61284c41a5cc1a5955c858db53c516b"><code>8c35066</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/a3dd8257252f392de5cf793c36ecab2acd955659"><code>a3dd825</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/c4e58023f22381508babfc52087853b5e3965b9c"><code>c4e5802</code></a> Docs: improve rule details for <code>no-console</code> (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14793">#14793</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14901">#14901</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/9052eee07a459dc059cd92f657a3ae73acc95bb5"><code>9052eee</code></a> Update: check class fields in no-extra-parens (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14906">#14906</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/5c3a47072aeb5cfda40a1eb20b43a10c5ca7aab3"><code>5c3a470</code></a> Docs: add class fields in no-multi-assign documentation (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14907">#14907</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/d234d890b383837f8e4bda0f6ce1e2a348f9835e"><code>d234d89</code></a> Docs: add class fields in func-names documentation (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14857">#14857</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14908">#14908</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/ae6072b1de5c8b30ce6c58290852082439c40b30"><code>ae6072b</code></a> Upgrade: <code>eslint-visitor-keys</code> to v3 (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14902">#14902</a>) (Bryan Mishkin)</li>
<li><a href="https://github.com/eslint/eslint/commit/e53d8cf9d73bd105cf6ba4f6b5477ccc4b980939"><code>e53d8cf</code></a> Upgrade: <code>markdownlint</code> dev dependencies (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14883">#14883</a>) (Bryan Mishkin)</li>
<li><a href="https://github.com/eslint/eslint/commit/d66e9414be60e05badb96bc3e1a55ca34636d7f8"><code>d66e941</code></a> Upgrade: <a href="https://github.com/humanwhocodes/config-array"><strong>@humanwhocodes/config-array</strong></a> to 0.6 (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14891">#14891</a>) (Bryan Mishkin)</li>
<li><a href="https://github.com/eslint/eslint/commit/149230ce7e296c029a0b6c085216fc0360ed4c65"><code>149230c</code></a> Chore: Specify Node 14.x for Verify Files CI job (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14896">#14896</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/537cf6a0e78ee9b7167e7f8c56f4053d3fb5b2d7"><code>537cf6a</code></a> Chore: update <code>glob-parent</code> (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14879">#14879</a>)(<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14887">#14887</a>) (Nitin Kumar)</li>
<li><a href="https://github.com/eslint/eslint/commit/f7b4a3f6a44e167c71985d373f73eebd3a4d9556"><code>f7b4a3f</code></a> Chore: update dev deps to latest (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14624">#14624</a>) (薛定谔的猫)</li>
<li><a href="https://github.com/eslint/eslint/commit/24c9f2ac57efcd699ca69695c82e51ce5742df7b"><code>24c9f2a</code></a> Breaking: Strict package exports (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/13654">#13654</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14706">#14706</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/86d31a4951e3a39e359e284f5fe336ac477369fe"><code>86d31a4</code></a> Breaking: disallow SourceCode#getComments() in RuleTester (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14744">#14744</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14769">#14769</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/1d2213deb69c5901c1950bbe648aa819e7e742ed"><code>1d2213d</code></a> Breaking: Fixable disable directives (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/11815">#11815</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14617">#14617</a>) (Josh Goldberg)</li>
<li><a href="https://github.com/eslint/eslint/commit/4a7aab7d4323ff7027eebca709d4e95a9aaa80bc"><code>4a7aab7</code></a> Breaking: require <code>meta</code> for fixable rules (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/13349">#13349</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14634">#14634</a>) (Milos Djermanovic)</li>
<li><a href="https://github.com/eslint/eslint/commit/d6a761f9b6582e9f71705161be827ca303ef183f"><code>d6a761f</code></a> Breaking: Require <code>meta.hasSuggestions</code> for rules with suggestions (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14573">#14573</a>) (Bryan Mishkin)</li>
<li><a href="https://github.com/eslint/eslint/commit/6bd747b5b7731195224875b952a9ea61445a9938"><code>6bd747b</code></a> Breaking: support new regex d flag (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14640">#14640</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14653">#14653</a>) (Yosuke Ota)</li>
<li><a href="https://github.com/eslint/eslint/commit/8b4f3abdb794feb3be31959bb44bfb0ef6318e8e"><code>8b4f3ab</code></a> Breaking: fix comma-dangle schema (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/13739">#13739</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14030">#14030</a>) (Joakim Nilsson)</li>
<li><a href="https://github.com/eslint/eslint/commit/b953a4ee12f120658a9ec27d1f8ca88dd3dfb599"><code>b953a4e</code></a> Breaking: upgrade espree and support new class features (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14343">#14343</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14591">#14591</a>) (Toru Nagashima)</li>
<li><a href="https://github.com/eslint/eslint/commit/8cce06cb39886902ce0d2e6882f46c3bf52fb955"><code>8cce06c</code></a> Breaking: add some rules to eslint:recommended (refs <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14673">#14673</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14691">#14691</a>) (薛定谔的猫)</li>
<li><a href="https://github.com/eslint/eslint/commit/86bb63b370e0ff350e988a5fa228a8234abe800c"><code>86bb63b</code></a> Breaking: Drop <code>codeframe</code> and <code>table</code> formatters (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14316">#14316</a>) (Federico Brigante)</li>
<li><a href="https://github.com/eslint/eslint/commit/f3cb3208c8952a6218d54658cfda85942b9fda42"><code>f3cb320</code></a> Breaking: drop node v10/v13/v15 (fixes <a href="https://github.com/redpeacock78/kyoto-art_news/issues/14023">#14023</a>) (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14592">#14592</a>) (薛定谔的猫)</li>
<li><a href="https://github.com/eslint/eslint/commit/b8b2d5553b0de23e8b72ee45949650cd5f9a10d2"><code>b8b2d55</code></a> Build: add codeql (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14729">#14729</a>) (薛定谔的猫)</li>
<li><a href="https://github.com/eslint/eslint/commit/e037d61a12ad17a36e05dcf65aa63fad303c79b9"><code>e037d61</code></a> Docs: Mention workaround for escaping the slash character in selectors (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14675">#14675</a>) (Aria)</li>
<li><a href="https://github.com/eslint/eslint/commit/81f03b6ad69c7f67ad6ba72e02e73266aa8f7696"><code>81f03b6</code></a> Docs: Update license copyright (<a href="https://github.com/redpeacock78/kyoto-art_news/issues/14877">#14877</a>) (Nicholas C. Zakas)</li>
<li><a href="https://github.com/eslint/eslint/commit/fa1c07c0d65ce21a30f5bb4a9f2ac511f8df6446"><code>fa1c07c</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/e31f49206f94e2b3977ec37892d4b87ab1e46872"><code>e31f492</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
<li><a href="https://github.com/eslint/eslint/commit/83072561b006a558d026c5a507f92945b821a0cd"><code>8307256</code></a> Sponsors: Sync README with website (ESLint Jenkins)</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: